### PR TITLE
feat: implement views on Notebook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"@libsql/client": "^0.15.4",
 				"arctic": "^3.6.0",
 				"codemirror": "^6.0.1",
+				"dayjs": "^1.11.13",
 				"dompurify": "^3.2.5",
 				"drizzle-orm": "^0.41.0",
 				"jose": "^6.0.10",
@@ -6129,6 +6130,12 @@
 			"engines": {
 				"node": ">=18"
 			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.13",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+			"integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"@libsql/client": "^0.15.4",
 		"arctic": "^3.6.0",
 		"codemirror": "^6.0.1",
+		"dayjs": "^1.11.13",
 		"dompurify": "^3.2.5",
 		"drizzle-orm": "^0.41.0",
 		"jose": "^6.0.10",

--- a/src/lib/cmpnt/Sparkline.svelte
+++ b/src/lib/cmpnt/Sparkline.svelte
@@ -15,7 +15,7 @@
 			const min = Math.min(...data);
 			const range = max === min ? max || 1 : max - min;
 			const width = 155;
-			const height = 28;
+			const height = 26;
 
 			return data
 				.map((value, index) =>
@@ -40,7 +40,7 @@
 			<stop offset="25%" stop-color="#46954a"></stop>
 			<stop offset="50%" stop-color="#6bc46d"></stop>
 		</linearGradient>
-		<mask id="sparkline-{uid}" x="0" y="0" width="155" height="28">
+		<mask id="sparkline-{uid}" x="0" y="0" width="155" height="26">
 			<polyline {points} fill="transparent" stroke="#8cc665" stroke-width="2" />
 		</mask>
 	</defs>

--- a/src/lib/cmpnt/Sparkline.svelte
+++ b/src/lib/cmpnt/Sparkline.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	interface Props {
+		data: number[];
+		title?: string;
+	}
+
+	let { data, title }: Props = $props();
+	const uid = $props.id();
+
+	const points = $derived.by(() => {
+		if (data.length < 2) {
+			return '';
+		} else {
+			const max = Math.max(...data);
+			const min = Math.min(...data);
+			const range = max === min ? max || 1 : max - min;
+			const width = 155;
+			const height = 28;
+
+			return data
+				.map((value, index) =>
+					[
+						((index / (data.length - 1)) * width).toFixed(2),
+						(height - ((value - min) / range) * height).toFixed(2)
+					].join(',')
+				)
+				.join(' ');
+		}
+	});
+</script>
+
+<svg width="155" height="30" aria-hidden="true">
+	{#if title}
+		<title>{title}</title>
+	{/if}
+	<defs>
+		<linearGradient id="gradient-{uid}" x1="0" x2="0" y1="1" y2="0">
+			<stop offset="0%" stop-color="#1b4721"></stop>
+			<stop offset="10%" stop-color="#2b6a30"></stop>
+			<stop offset="25%" stop-color="#46954a"></stop>
+			<stop offset="50%" stop-color="#6bc46d"></stop>
+		</linearGradient>
+		<mask id="sparkline-{uid}" x="0" y="0" width="155" height="28">
+			<polyline {points} fill="transparent" stroke="#8cc665" stroke-width="2" />
+		</mask>
+	</defs>
+
+	<g transform="translate(0, 2.0)">
+		<rect
+			x="0"
+			y="-2"
+			width="155"
+			height="30"
+			style="stroke: none; fill: url(#gradient-{uid}); mask: url(#sparkline-{uid})"
+		></rect>
+	</g>
+</svg>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -165,3 +165,22 @@ export const secrets = table(
 export const secretsRelations = relations(secrets, ({ one }) => ({
 	owner: one(users, { fields: [secrets.ownerId], references: [users.id] })
 }));
+
+export const views = table(
+	'views',
+	{
+		notebookId: int('notebook_id')
+			.notNull()
+			.references(() => notebooks.id, { onDelete: 'cascade' }),
+		clientId: int('client_id').notNull(),
+		hour: int().notNull(),
+		createdAt: int('created_at', { mode: 'timestamp' })
+			.notNull()
+			.default(sql`(unixepoch())`)
+	},
+	(t) => [primaryKey({ columns: [t.notebookId, t.clientId, t.hour] })]
+);
+
+export const viewsRelations = relations(views, ({ one }) => ({
+	notebook: one(notebooks, { fields: [views.notebookId], references: [notebooks.id] })
+}));

--- a/src/lib/server/repositories/views.ts
+++ b/src/lib/server/repositories/views.ts
@@ -1,10 +1,12 @@
 import days from 'dayjs';
+import { sql } from 'drizzle-orm';
 import { db, type DrizzleDatabase } from '../db';
 import { views } from '../db/schema';
+import type { Notebook } from './notebooks';
 
 const epoch = days.unix(1747758426);
 
-type NewView = Omit<typeof views.$inferInsert, 'createdAt' | 'hour'>;
+type NewView = { notebookId: Notebook['id']; clientIPAddress: string };
 
 export interface ViewRepository {
 	addView(view: NewView): Promise<void>;
@@ -13,19 +15,28 @@ export interface ViewRepository {
 class DrizzleViewRepository implements ViewRepository {
 	constructor(private db: DrizzleDatabase) {}
 
-	async addView({ clientId, notebookId }: NewView) {
+	async addView({ notebookId, clientIPAddress }: NewView) {
 		const now = new Date();
+
+		const clientId = await hash(clientIPAddress);
 
 		await this.db
 			.insert(views)
 			.values({
 				notebookId,
-				clientId,
+				clientId: sql`${clientId}`,
 				hour: days(now).diff(epoch, 'hours'),
 				createdAt: now
 			})
 			.onConflictDoNothing();
 	}
+}
+
+async function hash(ip: string) {
+	const data = new TextEncoder().encode(ip);
+	const buffer = await crypto.subtle.digest('SHA-256', data);
+	const view = new DataView(buffer);
+	return view.getBigInt64(0);
 }
 
 export const viewRepository: ViewRepository = new DrizzleViewRepository(db);

--- a/src/lib/server/repositories/views.ts
+++ b/src/lib/server/repositories/views.ts
@@ -1,0 +1,31 @@
+import days from 'dayjs';
+import { db, type DrizzleDatabase } from '../db';
+import { views } from '../db/schema';
+
+const epoch = days.unix(1747758426);
+
+type NewView = Omit<typeof views.$inferInsert, 'createdAt' | 'hour'>;
+
+export interface ViewRepository {
+	addView(view: NewView): Promise<void>;
+}
+
+class DrizzleViewRepository implements ViewRepository {
+	constructor(private db: DrizzleDatabase) {}
+
+	async addView({ clientId, notebookId }: NewView) {
+		const now = new Date();
+
+		await this.db
+			.insert(views)
+			.values({
+				notebookId,
+				clientId,
+				hour: days(now).diff(epoch, 'hours'),
+				createdAt: now
+			})
+			.onConflictDoNothing();
+	}
+}
+
+export const viewRepository: ViewRepository = new DrizzleViewRepository(db);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,9 @@
 	import OrderBy, { parseBy, parseDir } from '$lib/cmpnt/OrderBy.svelte';
 	import Pagination from '$lib/cmpnt/Pagination.svelte';
 	import ProfilePicture from '$lib/cmpnt/ProfilePicture.svelte';
+	import Sparkline from '$lib/cmpnt/Sparkline.svelte';
 	import BranchFork from '$lib/cmpnt/svg/branch-fork.svelte';
+	import Eye from '$lib/cmpnt/svg/eye.svelte';
 	import Tag from '$lib/cmpnt/Tag.svelte';
 	import type { PageProps } from './$types';
 	import { getTagHref, parse } from './search.utils';
@@ -25,6 +27,11 @@
 			data.trends.map((t) => t.name)
 		).tags
 	);
+
+	function sortCompare(a: { date: string; views: number }, b: { date: string; views: number }) {
+		const toDate = (x: { date: string; views: number }) => new Date(x.date);
+		return toDate(a).getTime() - toDate(b).getTime();
+	}
 </script>
 
 <svelte:head>
@@ -82,6 +89,16 @@
 							</div>
 						</div>
 					</div>
+				</div>
+				<div class="hide-tablet">
+					<Sparkline
+						title="{item.views} view{item.views > 1 ? 's' : ''}"
+						data={item.dailyViews.toSorted(sortCompare).map((v) => v.views)}
+					/>
+				</div>
+				<div class="total-views">
+					<span>{item.views}</span>
+					<Eye size="16" />
 				</div>
 			</li>
 		{/each}
@@ -198,9 +215,23 @@
 		gap: 10px;
 	}
 
+	.total-views {
+		display: none;
+		align-items: center;
+		gap: 5px;
+	}
+
 	@media screen and (max-width: 768px) {
 		.author-info > div {
 			display: none;
+		}
+
+		.hide-tablet {
+			display: none;
+		}
+
+		.total-views {
+			display: flex;
 		}
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,8 +28,8 @@
 		).tags
 	);
 
+	const toDate = (x: { date: string; views: number }) => new Date(x.date);
 	function sortCompare(a: { date: string; views: number }, b: { date: string; views: number }) {
-		const toDate = (x: { date: string; views: number }) => new Date(x.date);
 		return toDate(a).getTime() - toDate(b).getTime();
 	}
 </script>

--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -45,8 +45,8 @@
 		).tags
 	);
 
+	const toDate = (x: { date: string; views: number }) => new Date(x.date);
 	function sortCompare(a: { date: string; views: number }, b: { date: string; views: number }) {
-		const toDate = (x: { date: string; views: number }) => new Date(x.date);
 		return toDate(a).getTime() - toDate(b).getTime();
 	}
 </script>

--- a/src/routes/[username]/+page.svelte
+++ b/src/routes/[username]/+page.svelte
@@ -5,7 +5,9 @@
 	import OrderBy, { parseBy, parseDir } from '$lib/cmpnt/OrderBy.svelte';
 	import Pagination from '$lib/cmpnt/Pagination.svelte';
 	import ProfilePicture from '$lib/cmpnt/ProfilePicture.svelte';
+	import Sparkline from '$lib/cmpnt/Sparkline.svelte';
 	import BranchFork from '$lib/cmpnt/svg/branch-fork.svelte';
+	import Eye from '$lib/cmpnt/svg/eye.svelte';
 	import Heart from '$lib/cmpnt/svg/heart.svelte';
 	import Tag from '$lib/cmpnt/Tag.svelte';
 	import Visibility from '$lib/cmpnt/Visibility.svelte';
@@ -42,6 +44,11 @@
 			data.trends.map((t) => t.name)
 		).tags
 	);
+
+	function sortCompare(a: { date: string; views: number }, b: { date: string; views: number }) {
+		const toDate = (x: { date: string; views: number }) => new Date(x.date);
+		return toDate(a).getTime() - toDate(b).getTime();
+	}
 </script>
 
 <svelte:head>
@@ -103,6 +110,17 @@
 							</div>
 						</div>
 					</div>
+				</div>
+
+				<div class="hide-tablet">
+					<Sparkline
+						title="{item.views} view{item.views > 1 ? 's' : ''}"
+						data={item.dailyViews.toSorted(sortCompare).map((v) => v.views)}
+					/>
+				</div>
+				<div class="total-views">
+					<span>{item.views}</span>
+					<Eye size="16" />
 				</div>
 
 				<button
@@ -230,9 +248,23 @@
 		gap: 10px;
 	}
 
+	.total-views {
+		display: none;
+		align-items: center;
+		gap: 5px;
+	}
+
 	@media screen and (max-width: 768px) {
 		.author-info > div {
 			display: none;
+		}
+
+		.hide-tablet {
+			display: none;
+		}
+
+		.total-views {
+			display: flex;
 		}
 	}
 

--- a/src/routes/[username]/[slug]/+page.server.ts
+++ b/src/routes/[username]/[slug]/+page.server.ts
@@ -33,7 +33,7 @@ export const load = (async ({ params, locals, url, getClientAddress }) => {
 		});
 
 		await viewRepository.addView({
-			clientId: await hash(getClientAddress()),
+			clientIPAddress: getClientAddress(),
 			notebookId: notebook.id
 		});
 
@@ -48,14 +48,3 @@ export const load = (async ({ params, locals, url, getClientAddress }) => {
 		throw error(500, { message: e instanceof Error ? e.message : 'Something went wrong' });
 	}
 }) satisfies PageServerLoad;
-
-async function hash(ip: string) {
-	const data = new TextEncoder().encode(ip);
-	const buffer = await crypto.subtle.digest('SHA-256', data);
-
-	const hashHex = Array.from(new Uint8Array(buffer.slice(0, 8)))
-		.map((b) => b.toString(16).padStart(2, '0'))
-		.join('');
-
-	return parseInt(hashHex, 16);
-}

--- a/src/routes/[username]/[slug]/+page.svelte
+++ b/src/routes/[username]/[slug]/+page.svelte
@@ -7,6 +7,7 @@
 	import Select from '$lib/cmpnt/Select.svelte';
 	import BranchFork from '$lib/cmpnt/svg/branch-fork.svelte';
 	import DotsThree from '$lib/cmpnt/svg/dots-three.svelte';
+	import Eye from '$lib/cmpnt/svg/eye.svelte';
 	import FloppyDiskBack from '$lib/cmpnt/svg/floppy-disk-back.svelte';
 	import Globe from '$lib/cmpnt/svg/globe.svelte';
 	import PencilSimpleLine from '$lib/cmpnt/svg/pencil-simple-line.svelte';
@@ -285,6 +286,12 @@
 			</span>
 		</div>
 	{/if}
+	{#if data.notebook.views}
+		<div class="views">
+			<Eye size="16" />
+			<span>{data.notebook.views} view{data.notebook.views > 1 ? 's' : ''}</span>
+		</div>
+	{/if}
 </div>
 
 {#if tags.length}
@@ -426,8 +433,7 @@
 		margin: 8px 0;
 		padding: 16px 0;
 
-		& .updated_at,
-		& .fork_of {
+		& > div {
 			display: flex;
 			align-items: center;
 			gap: 4px;


### PR DESCRIPTION
### 📌 Context
We wanted to track notebook popularity and engagement over time, and surface this insight in the UI. This PR introduces view tracking and basic analytics for notebooks.

### ✅ What’s Changed
#### 🔧 Server Side

- **Created** `views` **table** to store notebook view events.
- Each view is logged **only once per client per interval** to avoid inflating metrics (client ID is derived from the user’s IP address).
- Enhanced `NotebookRepository.list` function to return:
  - **Total view count** per notebook
  - **Daily view counts for the last 7 days** (used for sparklines)
- Enhanced `NotebookRepository.read` function to return the  **Total view count**

#### 💻 Client Side
- On **desktop**: Added a **GitHub-style sparkline** to each notebook in the list.
- On **tablet/mobile**: Displayed only the **total view count** for cleaner UI.
- Displayed on the notebook page the **total view count**.

