### PR TITLE
fix: remove devtools error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,7 @@
 				"lodash": "^4.17.21",
 				"marked": "^15.0.8",
 				"normalize.css": "^8.0.1",
-				"p-debounce": "^4.0.0",
-				"shiki": "^3.2.2"
+				"p-debounce": "^4.0.0"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.8",
@@ -53,6 +52,7 @@
 				"typescript": "^5.8.3",
 				"typescript-eslint": "^8.30.1",
 				"vite": "^6.2.6",
+				"vite-plugin-devtools-json": "^0.1.0",
 				"vitest": "^3.1.1"
 			}
 		},
@@ -3647,73 +3647,6 @@
 				"win32"
 			]
 		},
-		"node_modules/@shikijs/core": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.2.2.tgz",
-			"integrity": "sha512-yvlSKVMLjddAGBa2Yu+vUZxuu3sClOWW1AG+UtJkvejYuGM5BVL35s6Ijiwb75O9QdEx6IkMxinHZSi8ZyrBaA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.2.2",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4",
-				"hast-util-to-html": "^9.0.5"
-			}
-		},
-		"node_modules/@shikijs/engine-javascript": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.2.2.tgz",
-			"integrity": "sha512-tlDKfhWpF4jKLUyVAnmL+ggIC+0VyteNsUpBzh1iwWLZu4i+PelIRr0TNur6pRRo5UZIv3ss/PLMuwahg9S2hg==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.2.2",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"oniguruma-to-es": "^4.1.0"
-			}
-		},
-		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
-			"integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.2.2",
-				"@shikijs/vscode-textmate": "^10.0.2"
-			}
-		},
-		"node_modules/@shikijs/langs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
-			"integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.2.2"
-			}
-		},
-		"node_modules/@shikijs/themes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
-			"integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/types": "3.2.2"
-			}
-		},
-		"node_modules/@shikijs/types": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
-			"integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
-		"node_modules/@shikijs/vscode-textmate": {
-			"version": "10.0.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-			"license": "MIT"
-		},
 		"node_modules/@smithy/abort-controller": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
@@ -4830,15 +4763,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/hast": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4852,15 +4776,6 @@
 			"integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/mdast": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "*"
-			}
 		},
 		"node_modules/@types/node": {
 			"version": "22.10.6",
@@ -4877,12 +4792,6 @@
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"license": "MIT",
 			"optional": true
-		},
-		"node_modules/@types/unist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-			"license": "MIT"
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.14",
@@ -5098,12 +5007,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
-		},
-		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-			"license": "ISC"
 		},
 		"node_modules/@vitest/expect": {
 			"version": "3.1.1",
@@ -5440,16 +5343,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/ccount": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-			"integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/chai": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
@@ -5482,26 +5375,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/character-entities-html4": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-			"integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-legacy": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/check-error": {
@@ -5616,16 +5489,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/comma-separated-tokens": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-			"integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/commander": {
@@ -6213,15 +6076,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/detect-libc": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
@@ -6237,19 +6091,6 @@
 			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/devlop": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
 		},
 		"node_modules/dompurify": {
 			"version": "3.2.5",
@@ -6840,12 +6681,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/emoji-regex-xs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-			"integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
-			"license": "MIT"
 		},
 		"node_modules/entities": {
 			"version": "4.5.0",
@@ -7567,42 +7402,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/hast-util-to-html": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/unist": "^3.0.0",
-				"ccount": "^2.0.0",
-				"comma-separated-tokens": "^2.0.0",
-				"hast-util-whitespace": "^3.0.0",
-				"html-void-elements": "^3.0.0",
-				"mdast-util-to-hast": "^13.0.0",
-				"property-information": "^7.0.0",
-				"space-separated-tokens": "^2.0.0",
-				"stringify-entities": "^4.0.0",
-				"zwitch": "^2.0.4"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/hast-util-whitespace": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-			"integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -7616,16 +7415,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/html-void-elements": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -8055,27 +7844,6 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/mdast-util-to-hast": {
-			"version": "13.2.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-			"integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/hast": "^3.0.0",
-				"@types/mdast": "^4.0.0",
-				"@ungap/structured-clone": "^1.0.0",
-				"devlop": "^1.0.0",
-				"micromark-util-sanitize-uri": "^2.0.0",
-				"trim-lines": "^3.0.0",
-				"unist-util-position": "^5.0.0",
-				"unist-util-visit": "^5.0.0",
-				"vfile": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8085,95 +7853,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/micromark-util-character": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-symbol": "^2.0.0",
-				"micromark-util-types": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-encode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/micromark-util-sanitize-uri": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"micromark-util-character": "^2.0.0",
-				"micromark-util-encode": "^2.0.0",
-				"micromark-util-symbol": "^2.0.0"
-			}
-		},
-		"node_modules/micromark-util-symbol": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/micromark-util-types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -8406,24 +8085,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/oniguruma-parser": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.11.1.tgz",
-			"integrity": "sha512-fX6SirDOsTUNqSUOnL3fDtD3R7PCXNWGA3WWPvv9egEfTWkNXzRLO/9CC1WkDusP6HyWRZig06kHeYPcw3mlqQ==",
-			"license": "MIT"
-		},
-		"node_modules/oniguruma-to-es": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.2.0.tgz",
-			"integrity": "sha512-MDPs6KSOLS0tKQ7joqg44dRIRZUyotfTy0r+7oEEs6VwWWP0+E2PPDYWMFN0aqOjRyWHBYq7RfKw9GQk2S2z5g==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex-xs": "^1.0.0",
-				"oniguruma-parser": "^0.11.0",
-				"regex": "^6.0.1",
-				"regex-recursion": "^6.0.2"
-			}
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -8767,16 +8428,6 @@
 			"integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
 			"license": "ISC"
 		},
-		"node_modules/property-information": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
-			"integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8821,30 +8472,6 @@
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
 			}
-		},
-		"node_modules/regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/regex/-/regex-6.0.1.tgz",
-			"integrity": "sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==",
-			"license": "MIT",
-			"dependencies": {
-				"regex-utilities": "^2.3.0"
-			}
-		},
-		"node_modules/regex-recursion": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
-			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-			"license": "MIT",
-			"dependencies": {
-				"regex-utilities": "^2.3.0"
-			}
-		},
-		"node_modules/regex-utilities": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-			"license": "MIT"
 		},
 		"node_modules/regexparam": {
 			"version": "3.0.0",
@@ -9115,22 +8742,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/shiki": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-3.2.2.tgz",
-			"integrity": "sha512-0qWBkM2t/0NXPRcVgtLhtHv6Ak3Q5yI4K/ggMqcgLRKm4+pCs3namgZlhlat/7u2CuqNtlShNs9lENOG6n7UaQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@shikijs/core": "3.2.2",
-				"@shikijs/engine-javascript": "3.2.2",
-				"@shikijs/engine-oniguruma": "3.2.2",
-				"@shikijs/langs": "3.2.2",
-				"@shikijs/themes": "3.2.2",
-				"@shikijs/types": "3.2.2",
-				"@shikijs/vscode-textmate": "^10.0.2",
-				"@types/hast": "^3.0.4"
-			}
-		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -9196,16 +8807,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/space-separated-tokens": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-			"integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9242,20 +8843,6 @@
 			"engines": {
 				"node": ">=4",
 				"npm": ">=6"
-			}
-		},
-		"node_modules/stringify-entities": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-			"integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-			"license": "MIT",
-			"dependencies": {
-				"character-entities-html4": "^2.0.0",
-				"character-entities-legacy": "^3.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -9510,16 +9097,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/trim-lines": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-			"integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/ts-api-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
@@ -9632,74 +9209,6 @@
 				"ufo": "^1.5.4"
 			}
 		},
-		"node_modules/unist-util-is": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-			"integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-position": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-			"integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-stringify-position": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-visit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-is": "^6.0.0",
-				"unist-util-visit-parents": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-visit-parents": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-			"integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-is": "^6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9728,34 +9237,6 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist/bin/uuid"
-			}
-		},
-		"node_modules/vfile": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"vfile-message": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile-message": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-			"integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/unist": "^3.0.0",
-				"unist-util-stringify-position": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/vite": {
@@ -9851,6 +9332,33 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vite-plugin-devtools-json": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-devtools-json/-/vite-plugin-devtools-json-0.1.0.tgz",
+			"integrity": "sha512-KvdgPBUAAhwnpOgXmJhs6KI4/IPn6xUppLGm20D0Uvp/doZ9TpTYYfzSHX0TgvdsSlTAwzZfzDse+ujGskp68g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uuid": "^11.1.0"
+			},
+			"peerDependencies": {
+				"vite": "^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+			}
+		},
+		"node_modules/vite-plugin-devtools-json/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/vitefu": {
@@ -10252,16 +9760,6 @@
 			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zwitch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"typescript": "^5.8.3",
 		"typescript-eslint": "^8.30.1",
 		"vite": "^6.2.6",
+		"vite-plugin-devtools-json": "^0.1.0",
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
@@ -62,7 +63,6 @@
 		"lodash": "^4.17.21",
 		"marked": "^15.0.8",
 		"normalize.css": "^8.0.1",
-		"p-debounce": "^4.0.0",
-		"shiki": "^3.2.2"
+		"p-debounce": "^4.0.0"
 	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import devtoolsJson from 'vite-plugin-devtools-json';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [sveltekit(), devtoolsJson()],
 
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
-	},
-	ssr: {
-		external: ['shiki']
 	}
 });


### PR DESCRIPTION
### 📌 Context
When opening the DevTools panel in development mode, an error was being logged:
```
SvelteKitError: Not found: /.well-known/appspecific/com.chrome.devtools.json
```

### ✅ What’s Changed
- Added `vite-plugin-devtools-json` dependencies and configure the plugin on vite config

### 📎 Notes
This does not affect production, but improves the DX (developer experience) by removing distracting errors during local development.
I took the opportunity to uninstall the unused `shiki` dependency.